### PR TITLE
Add Node.js boilerplate folder

### DIFF
--- a/nodejs-template/README.md
+++ b/nodejs-template/README.md
@@ -1,0 +1,27 @@
+# Node.js Boilerplate – Launch Base
+
+A beginner-friendly Node.js starter template using the built-in `http` module.
+
+## 🚀 Getting Started
+
+1. Install dependencies (optional but standard):
+   ```bash
+   npm install
+
+2. Start the server:
+   ```bash
+   npm start
+
+3. Visit in your browser:
+    ```bash
+    http://localhost:3000
+
+You should see the message:
+Hello from launch-base Node.js boilerplate!
+
+Files Included:
+- package.json: Project metadata and start script
+- app.js: Basic HTTP server
+- README.md: Instructions for setup and usage
+
+You can personalize this slightly if you'd like, but this version is clear, friendly, and fits well with the other templates in the repo.

--- a/nodejs-template/app.js
+++ b/nodejs-template/app.js
@@ -1,0 +1,13 @@
+const http = require('http');
+
+const PORT = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello from launch-base Node.js boilerplate!\n');
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}/`);
+});

--- a/nodejs-template/package.json
+++ b/nodejs-template/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nodejs-template",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}


### PR DESCRIPTION
Adds a beginner-friendly Node.js starter template using `http.createServer`.

- Includes `package.json` with a start script
- `app.js` with a basic HTTP server on port 3000
- `README.md` with clear usage instructions

Fixes #2 
